### PR TITLE
Load level on death

### DIFF
--- a/Assets/scripts/PlayerEvents.cs
+++ b/Assets/scripts/PlayerEvents.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -26,17 +27,17 @@ public class PlayerEvents : MonoBehaviour {
     /**
      * Respawn(): Respawns the player at the last checkpoint
      */
-    private void Respawn() {
-        transform.position = gm.lastCheckPointPosition;
+    public static void Respawn() {
+        Application.LoadLevel(Application.loadedLevel);
     }
 
     /**
      * CheckDeath(): Checks if the player has died and respawns it
      */
+    [Obsolete("Obsolete")]
     private void CheckDeath() {
         if (IsPlayerDeath()) {
             Respawn();
-            playerHealth = _defaultPlayerHealth;
         }
     }
 

--- a/Assets/scripts/PlayerEvents.cs
+++ b/Assets/scripts/PlayerEvents.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class PlayerEvents : MonoBehaviour {
     [SerializeField] public int playerHealth = 3;
 
-    private const int _defaultPlayerHealth = 3;
     private GameMaster gm;
 
     // Start is called before the first frame update
@@ -28,13 +28,12 @@ public class PlayerEvents : MonoBehaviour {
      * Respawn(): Respawns the player at the last checkpoint
      */
     public static void Respawn() {
-        Application.LoadLevel(Application.loadedLevel);
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
 
     /**
      * CheckDeath(): Checks if the player has died and respawns it
      */
-    [Obsolete("Obsolete")]
     private void CheckDeath() {
         if (IsPlayerDeath()) {
             Respawn();

--- a/Assets/scripts/PlayerMovement.cs
+++ b/Assets/scripts/PlayerMovement.cs
@@ -96,15 +96,8 @@ public class PlayerMovement : MonoBehaviour {
      */
     private void CheckFall() {
         if (transform.position.y < DefaultVerticalFallPosition) {
-            Respawn();
+            PlayerEvents.Respawn();
         }
-    }
-
-    /**
-     * Respawn(): Respawns the player at the last checkpoint
-     */
-    private void Respawn() {
-        transform.position = gm.lastCheckPointPosition;
     }
 
     /**


### PR DESCRIPTION
Now, instead of resetting player variables manually it is done by loading the scene in respawn call. This improves the scalability and readability of the code.